### PR TITLE
55 - Add google analytics to allow tracking of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## Configuration
 
+### AWS configuration
 Provide AWS credentials and the name of your S3 bucket that contains project data.
 You may skip `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` if proper credentials were set in AWS configuration file (`~/.aws/credentials` in Linux, OS X, or Unix).
 
@@ -12,16 +13,20 @@ AWS_SECRET_ACCESS_KEY=xxxxxxxx
 S3_BUCKET_NAME=xxxxxxxxx
 ```
 
+### Cookie configuration
 Set a secret string for your cookies
 
 `COOKIE_SECRET=xxxxxxxxxxxxxx`
 
+### Log Level Configuration
 Set the logging level for the entire application
 
 `LOGGING_LEVEL=warn`
 
+
+### Azure Active Directory Configuration
 To enable Azure AD sign-in, set the following environment variables:
- 
+
 ```
 AZURE_IDENTITY_METADATA=https://login.microsoftonline.com/YOUR_TENANT_NAME_OR_ID/.well-known/openid-configuration
 AZURE_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx
@@ -31,3 +36,10 @@ AZURE_RETURN_URL=https://xxxxxxxxxxx.com/auth/openid/return
 
 To learn more about the above values, click [here](https://azure.microsoft.com/en-us/documentation/articles/active-directory-b2c-reference-oidc/#get-a-token).
 Additional Azure AD settings can be found in [configAzureAD.js](app/configAzureAD.js)
+
+### Google Analytics Configuration
+To enable google Analytics, set the following environment variables
+
+```
+GA_ID = XX-XXXXXXX-X
+```

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -4,3 +4,16 @@
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>
 <script src="/public/javascripts/application.js"></script>
 <script src="/public/javascripts/cookie.js"></script>
+
+{% if ga_id %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ ga_id }}', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endif %}

--- a/server.js
+++ b/server.js
@@ -64,9 +64,9 @@ if (!process.env.COOKIE_SECRET) {
     log.warn('COOKIE_SECRET is not set. Unsafe cookie secret will be used instead.');
 }
 app.use(cookieParser(process.env.COOKIE_SECRET || "unsafe-secret-CHANGE-ME"));
-app.use(session({ cookie: { 
+app.use(session({ cookie: {
     maxAge: 15 * 60 * 1000 // 15 minutes
-}})); 
+}}));
 app.use(flash());
 
 // all routes will have access to this flash message
@@ -88,6 +88,9 @@ if (typeof(routes) != "function") {
     app.use("/", routes);
     app.use("/", authRoutes);
 }
+
+// set ga tracking id
+app.locals.ga_id = process.env.GA_ID;
 
 // start the app
 app.listen(port);


### PR DESCRIPTION
Closes #55 

## Who can review?
Anyone but Rory.

## How to review?
Eyeball code.

Follow readme to configure environment variable. Run.

## What changed?

Google analytics has been added so we can better track usage of the
dashboard. Previously we didn't know if it was actively being used.

To allow all views to make use of analytics we added it to scripts.html
which itself is included in all layouts. We made use of app.locals to
add the value 'globally' so it could be referenced in the scripts.html.

If you don't have the GA_ID set in your environment variables it won't
include the tracking code.