### PR TITLE
Change default view for landing page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -30,10 +30,10 @@ var healthGroupFunc = function(p) {
 };
 
 var controller = new controllers(router);
-controller.setupIndexPageRoute('location', ['/', '/location']);
+controller.setupIndexPageRoute('location', '/location');
 controller.setupIndexPageRoute('agency', '/agency');
 controller.setupIndexPageRoute('theme', '/theme');
-controller.setupIndexPageRoute(healthGroupFunc, '/health', health_order, 'health');
+controller.setupIndexPageRoute(healthGroupFunc, ['/', '/health'], health_order, 'health');
 controller.setupIndexPageRoute('priority', '/priority', priority_order);
 
 router.get('/projects/add', connect.ensureLoggedIn(), controller.handleAddProject);


### PR DESCRIPTION
Closes #58 

Changed the default grouping for the landing page as health should be
the main focus for the dashboard. Location was not a useful default
grouping for users.

controller.setupIndexPageRoute was updated to have the root route
'/' display the health grouping.