### PR TITLE
Improve layout and styling to make health more obvious

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -170,15 +170,39 @@ $risk-colour: $orange;
 .phase.beta      {background-color:$beta-colour;}
 .phase.live      {background-color:$live-colour;}
 
-.circle.good      {background-color:$good-colour;}
-.circle.fair      {background-color:$fair-colour;}
-.circle.risk      {background-color:$risk-colour;}
-.circle.unknown   {background-color:grey;}
-
 .health.good      {background-color:$good-colour;}
 .health.fair      {background-color:$fair-colour;}
 .health.risk      {background-color:$risk-colour;}
 .health.unknown   {background-color:grey;}
+
+.health-block {
+  display: inline-block;
+  @include box-sizing(content-box);
+  margin: 10px;
+  padding: 20px;
+  border: none;
+  color: white;
+}
+
+.health-block a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.health-block a.visited {
+  text-decoration: none;
+  color: inherit;
+}
+
+.health-block a.link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.good      {background-color:$good-colour;}
+.fair      {background-color:$fair-colour;}
+.risk      {background-color:$risk-colour;}
+.unknown   {background-color:grey;}
 
 .phase_modifier {
   font-size:16px;

--- a/app/controllers.js
+++ b/app/controllers.js
@@ -40,20 +40,20 @@ Controller.prototype.handleApiAddProject = function(req, res) {
     newProject.setPhaseHistoryEntry(req.body.phase, "Started", req.body.month, req.body.year);
     newProject.setIsFinished(req.body.isFinished);
     newProject.setCustomer(req.body.customer);
-    
+
     projectDao.addProject(newProject, function(err, project) {
         log.trace('Adding project: ' + project.name);
         if(err) {
             log.debug('Error adding project with id = ' + project.id);
 
-            apiUtils.handleResultSet(res, 500, 
+            apiUtils.handleResultSet(res, 500,
                 new ApiResponse(null, ['Error adding project'])
             );
         } else {
             log.debug('Project with id = ' + project.id + ' has been added');
 
             projectCache.refreshProject(project.id);
-            apiUtils.handleResultSet(res, 200, 
+            apiUtils.handleResultSet(res, 200,
                 new ApiResponse({projectId: project.id}, ['The project has been added'])
             );
         }
@@ -918,7 +918,7 @@ Controller.prototype.setupIndexPageRoute = function(groupBy, path, rowOrder, vie
 
 /**
  * Prepare row order
- * 
+ *
  * @param  {String[]} [rowOrder] list that forces the order of values by which the projects are grouped
  * @param  {Object[]} data projects
  * @return {String[]} list showing the order of values by which the projects are grouped
@@ -951,7 +951,7 @@ function indexify(data) {
     return new_data;
 }
 
-// If phaseName was provided, trim projects that don't belong to that phase 
+// If phaseName was provided, trim projects that don't belong to that phase
 // Otherwise return unmodified data
 function filterPhaseIfPresent(data, phaseName) {
     if (typeof phaseName !== "undefined" && phaseName !== "all") {

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,10 +19,10 @@ var priority_order = [
 ];
 
 var health_order = [
-  'good',
-  'fair',
+  'unknown',
   'risk',
-  'unknown'
+  'fair',
+  'good'
 ];
 
 var healthGroupFunc = function(p) {

--- a/app/views/display-health.html
+++ b/app/views/display-health.html
@@ -1,76 +1,42 @@
 {% extends "layout.html" %} {% block content %}
 <main id="content" role="main">
     <div class="grid-row">
-        <section class="column-two-thirds">
-            <h1 class="font-xlarge">{{ project.name }} Health</h1>
-            <p class="location font-xsmall">{{ project.location }}</p>
-            <p><a class="font-xsmall" href="/projects/{{ project.id }}/{{ project.name | slugify }}"> Back to project page</a> <a class="font-xsmall" href="/projects/{{ project.id }}/{{ project.name | slugify }}/edit-health">Update Health</a>
-            </p>
-            <p>The overall health of "{{ project.name }}" can be seen above, with a listing of individual state outlined below. Scroll further to view the history of changes. You can update the status from the link above.</p>
-        </section>
-        <section class="column-third">
-            <p class="phase {{ project.phase | lower }}">phase <strong>{{ project.phase | title }}</strong></p>
-            <p class="health {{ project.health.overall.status | lower }}">health <strong>{{ project.health.overall.status | title }}</strong></p>
-        </section>
+        <div class="column-two-thirds">
+            <h1 class="heading-xlarge">{{ project.name }} Health <a class="font-xsmall" href="/projects/{{ project.id }}/{{ project.name | slugify }}/edit-health"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></h1>
+        </div>
     </div>
     <div class="grid-row">
-        <section class="column-full">
-            <h2 class="font-large">{{ project.name }} current state</h2>
-        </section>
+        <div>
+          {% set types = { "overall":{label: "Overall"}, "engineering": {label: "Engineering"}, "ops": {label: "Operations"}, "userResearch": {label: "User Research"}, "security": {label: "Security"}, "delivery": {label: "Delivery"}, "data": {label: "Data"} } %}
+          {% for type, details in types %}
+            {% if project.health[type] %}
+              <span class="health-block bold-xlarge {{ project.health[type].status | lower }}">{{ details.label | title }}</span>
+            {% endif %}
+          {% endfor %}
+        </div>
     </div>
-    {% set types = { "overall":{label: "Overall"}, "engineering": {label: "Engineering"}, "ops": {label: "Operations"}, "userResearch": {label: "User Research"}, "security": {label: "Security"}, "delivery": {label: "Delivery"}, "data": {label: "Data"} } %} {% for type, details in types %} {% if project.health[type] %}
-    <div class="grid-row" style="padding-top: 20px">
-        <section class="column-fifth">
-            <div class="health-circle">
-                <strong class="bold-small">{{ details.label | title }}</strong>
-                <p class="circle {{ project.health[type].status | lower }}"></p>
-                <p class="circle-label">{{ project.health[type].status | title }}</p>
-            </div>
-        </section>
-        <section class="column-four-fifths">
-                <p>{{ project.health[type].comment }}</p>
-                <p class="font-xsmall"><a href="{{ project.health[type].link.url }}">{{ project.health[type].link.name }}</a> {{ project.health[type].user.name }} {{ convertDate(project.health[type].date) }} </p>
-        </section>
-    </div>
-    <hr/>
-    {% endif %} {% endfor %}    
     <div class="grid-row">
-        <section class="column-full">
-            <h2 class="font-large">Previous {{ project.name }} health states</h2>
+        <div class="column-full">
+            <h2 class="heading-large">Health update detail</h2>
             <table>
                 <thead>
                     <tr>
-                        <td>Healthcheck Type and Link</td>
-                        <td>Author and Date</td>
-                        <td>Comment</td>
-                        <td>Status</td>
+                        <th>Healthcheck Type</th>
+                        <th>Status</th>
+                        <th>Comment</th>
+                        <th>Author and Date</th>
                     </tr>
                 </thead>
                 {% for status in history %}
                 <tr>
-                    <td>
-                        <div><strong class="bold-small">{{ types[status.type].label | title }}</strong></div>
-                        <a href="{{ status.link.url }}">
-                        {{ status.link.name }}
-                    </a>
-                    </td>
-                    <td>
-                        <a href="mailto:{{ status.user.email}}">
-                        {{ status.user.name }}
-                    </a> {% if status.date %}
-                        <div>{{ convertDate(status.date) }}</div>
-                        {% endif %}
-                    </td>
-                    <td>
-                        <div>{{ status.comment }}</div>
-                    </td>
-                    <td>
-                        <div class="health {{ status.status | lower }}">{{ status.status | title}}</div>
-                    </td>
+                    <td>{{ types[status.type].label | title }}</td>
+                    <td>{{ status.status | title}}</td>
+                    <td><p>{{ status.comment }}</p> <p>More detail <a href="{{ status.link.url }}" target="_blank">{{ status.link.name }}</a></p></td>
+                    <td>{{ status.user.name }}{% if status.date %}, {{ convertDate(status.date) }} {% endif %}</td>
                 </tr>
                 {% endfor %}
             </table>
-        </section>
+        </div>
     </div>
 </main>
 {% endblock %}

--- a/app/views/edit-resource.html
+++ b/app/views/edit-resource.html
@@ -13,8 +13,8 @@
             <form action="#" class="form" id="resource-form">
                 <input type="hidden" class="form-control" id="resourceId" name="resource[id]" value="{{ resource.id }}">
                 <div class="form-group">
-                    <label class="form-label-bold" for="name">Name</label>
-                    <p class="form-hint">Link name</p>
+                    <label class="form-label-bold" for="name">What is it?</label>
+                    <p class="form-hint">What are you linking to?</p>
                     <input type="text" class="form-control" id="name" name="resource[name]" value="{{ resource.name }}">
                 </div>
                 <div class="form-group">

--- a/app/views/edit-resources.html
+++ b/app/views/edit-resources.html
@@ -14,11 +14,11 @@
                 <table>
                     <thead>
                         <tr>
-                            <td>Name</td>
-                            <td>URL</td>
-                            <td>
+                            <th>What is it?</th>
+                            <th>URL</th>
+                            <th>
                                 &nbsp;
-                            </td>
+                            </th>
                         </tr>
                     </thead>
                     {% for resource in resources %}
@@ -51,13 +51,13 @@
             <div id="add-new-resource" style="display: none;">
                 <form action="#" method="POST" class="form" id="add-new-resource-form">
                     <div class="form-group">
-                        <label class="form-label-bold" for="name">Name</label>
-                        <p class="form-hint">Name for the link to the resource</p>
+                        <label class="form-label-bold" for="name">What are you Linking to?</label>
+                        <p class="form-hint">Description for the link</p>
                         <input type="text" class="form-control" id="name" name="name">
                     </div>
                     <div class="form-group">
                         <label class="form-label-bold" for="url">URL</label>
-                        <p class="form-hint">Web address of the resource</p>
+                        <p class="form-hint">Web address of the link</p>
                         <input type="url" class="form-control" id="url" name="url">
                     </div>
                     <div class="form-group">

--- a/app/views/includes/propositional_navigation.html
+++ b/app/views/includes/propositional_navigation.html
@@ -2,7 +2,7 @@
   <div class="content">
     <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
     <nav id="proposition-menu">
-      <a href="/" id="proposition-name">Project Dashboard</a>
+      <a href="/" id="proposition-name"><i class="fa fa-medkit" aria-hidden="true"></i> Project Dashboard</a>
       <ul id="proposition-links">
         <li><a href="/">Home</a></li>
         <li><a href="/projects/add">Add Project</a></li>

--- a/app/views/project.html
+++ b/app/views/project.html
@@ -1,52 +1,38 @@
 {% extends "layout.html" %} {% block content %}
 <main id="content" role="main">
     <div class="grid-row">
-        <section class="column-two-thirds">
-            <h1 class="font-xlarge">{{ data.name }}</h1>
-            <p class="location font-xsmall">{{ data.location }}</p>
-            {% if data.isFinished %}
-                <p class="health good font-xsmall" title="This project was finished">
-                    <i class="fa fa-flag-checkered" aria-hidden="true"></i>
-                    Finished
-                </p>
-            {% endif %}
-            <p><a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit">Change details</a> <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/display-health">Change health</a></p>
-            <p>{{ data.description }}</p>
-        </section>
-        <section class="column-third">
-            <p class="phase {{ data.phase | lower }}">phase <strong>{{ data.phase | title }}</strong></p>
-            <p class="health {{ data.health.overall.status | lower }}">health <strong>{{ data.health.overall.status | title }}</strong></p>
-            {% if data.customer %}
-                <div class="customer">
-                    <h2 class="font-medium">Customer</h2>
-                    <p>{{ data.customer }}</p>
-                </div>
-            {% endif %}
-        </section>
+      <div class="column-two-thirds">
+          <h1 class="heading-xlarge">{{ data.name }} <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></h1>
+          <p class="lede">{{ data.description }}</p>
+      </div>
+      <div class="column-quarter">
+          <span class="health-block bold-xlarge {{ data.health.overall.status | lower }}"><a href="/projects/{{ data.id }}/{{ data.name | slugify }}/display-health">{{ data.health.overall.status | title }}</a>&nbsp;<a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/display-health"><i class="fa fa-eye" aria-hidden="true"></i></a></span>
+      </div>
     </div>
     <div class="grid-row">
-        <section class="column-two-thirds">
-            <h2 class="font-large">Useful Links</h2>
-            <p>
-                {% if data["resources"].length > 0 %}
-                <ul class="link-list">
-                    {% for resource in data["resources"] %}
-                    <li><a href="{{ resource['url'] }}">{{ resource["name"] }}</a></li>
-                    {% endfor %}
-                </ul>
-                {% else %}
-                <ul class="link-list">
-                    <li>We don't have any links for this project.</li>
-                </ul>
-                {% endif %}
-            </p>
-            <p class="font-xsmall"> <a href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-resources">Change links</a></p>
-        </section>
+        <div class="column-two-thirds">
+            <h2 class="heading-large">Useful Links <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-resources"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></h3>
+        </div>
     </div>
     <div class="grid-row">
-        <section class="column-two-thirds">
-            <h2 class="font-large">People</h2>
-        </section>
+        <div class="column-two-thirds">
+          {% if data["resources"].length > 0 %}
+              <table>
+                  {% for resource in data["resources"] %}
+                  <tr>
+                      <td><a href="{{ resource['url'] }}" target="_blank">{{ resource["name"] }} </a></td>
+                  </tr>
+                  {% endfor %}
+                </table>
+          {% else %}
+          <p>We don't have any links for this project.</p>
+          {% endif %}
+        </div>
+    </div>
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            <h2 class="heading-large">People</h3>
+        </div>
     </div>
     <div class="grid-row">
         <!--MACRO FOR PEOPLE TABLE-->
@@ -56,18 +42,18 @@
             <table>
                 <thead>
                     <tr>
-                        <td>Role</td>
-                        <td>Name</td>
-                        <td>
+                        <th>Role</th>
+                        <th>Name</th>
+                        <th>
                             <!-- column for "more" buttons -->
-                        </td>
+                        </th>
                     </tr>
                 </thead>
                 {% for teamMember in peopleData %}
                 <tr>
                     <td>{{ teamMember.role}}</td>
                     <td>{{ teamMember.name }}</td>
-                    <td data-collapsable-parent="{{ teamName + loop.index }}" class="clickable">[+]</td>
+                    <td data-collapsable-parent="{{ teamName + loop.index }}" class="clickable"><i class="fa fa-plus-square-o" aria-hidden="true"></i></td>
                 </tr>
                 <tr>
                     <td data-collapsable-child="{{ teamName + loop.index }}" colspan="3">
@@ -100,24 +86,24 @@
         {% endmacro %}
         <!--MACRO FOR PEOPLE TABLE-->
         <section class="column-half">
-            <p class="font-medium">Our team <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-our-team">Change team members</a></p>
+            <p class="font-medium">Our team <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-our-team"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></p>
             {{ peopleTable(data["ourTeam"], "Kainos") }}
             <p></p>
         </section>
         <section class="column-half">
-            <p class="font-medium">Client team <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-client-team">Change team members</a></p>
+            <p class="font-medium">Client team <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-client-team"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></p>
             {{ peopleTable(data["clientTeam"], "Client") }}
             <p></p>
         </section>
     </div>
+
     <div class="grid-row">
         <section class="column-third">
-            <h2 class="font-large">Project history</h2>
-            <p><a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-phase-history">Manage project history</a></p>
+            <h2 class="heading-large">Project history <a class="font-xsmall" href="/projects/{{ data.id }}/{{ data.name | slugify }}/edit-phase-history"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a></h2>
             <div class="phase-history">
                 {% for phase in phase_order %} {% if data.phaseHistory[phase] %}
                 <div class="phase-history-item border-{{phase}} txt-{{phase}}">
-                    <h3><a href="#" class="tag tag-history {{phase}}">{{ phase }}</a></h3> 
+                    <h3><a href="#" class="tag tag-history {{phase}}">{{ phase }}</a></h3>
                     {% for label, item in data.phaseHistory[phase] | dictsort | reverse %}
                         <p>
                             {{ label }} &mdash; {{ item.month }} {{ item.year }}
@@ -132,8 +118,8 @@
         </section>
     </div>
 </main>
-{% endblock %} 
-{% block body_end %} 
+{% endblock %}
+{% block body_end %}
     {{ super() }}
     <script>
         function removeFromHistory(phase, label) {


### PR DESCRIPTION
Closes #56 and #57 

Based on user feedback we have made a number of changes to the layout
and styling of the dashboard to make data more accessible and obvious.

Corrected a number of incorrectly used classes on headers so proper
spacing is in place around header elements, new health block style to
allow a more 'radiator' style display and removed some content and text
that was redundant to reduce clutter.